### PR TITLE
Postman instructions & example params

### DIFF
--- a/InstanceExport/PowerShell/README.md
+++ b/InstanceExport/PowerShell/README.md
@@ -7,32 +7,31 @@ In order to use it, you should:
 1. Download the InstanceExport power shell script available in this repo to your machine.
 
 2. Use DevResults API to make a POST request an updated Instance Export Manifest:
- ```POST https://{myInstanceName}.devresults.com/api/currentinstance/export```
 
-where {myInstanceName} is the name of your site in DevResults
+    `POST https://{myInstanceName}.devresults.com/api/currentinstance/export`
 
-3. Save the file in the same directory you have saved the powershell script. It's important to save the file in the JSON format and that you keep in mind the name you saved the file. In this tutorial the name we used is *manifest.json*
+    where {myInstanceName} is the name of your site in DevResults. For detailed instructions on making a POST request to the DevResults API, please see our [knowledge base article for help with using Postman](https://help.devresults.com/help/devresults-api). 
 
-4. Open a new command line interface (CLI) prompt that supports using of PowerShell commands. If you don't have PowerShell installed you can follow instructions at [Installing Power Shell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.1)
+3. Save the file in the same directory you have saved the powershell script. It's important to save the file in the JSON format and that you remember what you named the file. In this tutorial the name we used is *manifest.json*.
 
-5. Navigate to the directory you have saved the InstanceExport.ps1 and the JSON manifest file.
+4. Open a new command line interface (CLI) prompt that supports using of PowerShell commands. If you don't have PowerShell installed you can follow instructions at [Installing Power Shell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.1).
 
-e.g.: cd C:\Users\MyUser\InstanceExport
+5. Navigate to the directory you have saved the InstanceExport.ps1 and the JSON manifest file. 
 
-6. In the cli prompt type the following command
+    e.g.: `cd C:\Users\MyUser\InstanceExport`
+
+6. In the cli prompt type the following command.
    
-   ```
-   .\InstanceExport
-   ```
+    `.\InstanceExport`
 
-The process will prompt to you the mandatory fields to be typed in your screen $manifestFilePath, $exportFilePath, $userName and $password. 
-It will run automatically after you enter the fields and it will propmt the progress of your data been exported by each available category. When all is finishedd you should see a message "Exporting Instance finished"
+The process will prompt to you the mandatory fields to be typed in your screen `$manifestFilePath`, `$exportFilePath`, `$userName` and `$password`. 
+It will run automatically after you enter the fields and it will propmt the progress of your data been exported by each available category. When all is finishedd you should see the message "Exporting Instance finished".
 
 The created power shell script has five parameters that are explained below:
-- manifestFilePath : Path of the manifest file you have downloaded using step 2
-- exportFilePath: Path to create the folder for the exported files
-- userName: Your username for login at DevResults
+- manifestFilePath: Path of the manifest file you have downloaded using step 2, e.g. `C:\Users\MyUser\InstanceExport\manifest.json`
+- exportFilePath: Path to create a folder for the exported files, e.g. `C:\Users\MyUser\InstanceExport\2021_Export\`
+- userName: Your username (work email) for login at DevResults, e.g. `first.last@org.org`
 - password: Your password for login at DevResults or API Key's Secret
 - overwrite: Optional parameter to inform if you want to overwrite files that already exist and replace them. If you don't use the value of it will be false, which means that if a file already exists in the exportFilePath it will be skipped.
 
-PS.: Alternatively, you can right click in the InstanceExport.ps1 file, choose "run with powershell" and follow the prompst too.
+PS.: Alternatively, you can right click in the `InstanceExport.ps1` file, choose "run with powershell" and then follow the prompts.


### PR DESCRIPTION
Added link to Postman instructions, added examples for parameters, tweaked some formatting.

Are those examples correct? They worked for me. In my first attempt I had quotes around the strings and that didn't work, so I thought examples would be good. 