### PR TITLE
Adding CI build for InstanceExport

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,11 @@ jobs:
           (Get-Content -path InstanceExport/PowerShell/InstanceExport.ps1 -Raw) -replace '-1.0.0-dev-','1.0.0-${{ github.sha }}' | Set-Content -Path InstanceExport/PowerShell/InstanceExport.ps1
           (Get-Content -path InstanceExport/PowerShell/InstanceExport.ps1 -Raw) -replace '-githubsha-','${{ github.sha }}' | Set-Content -Path InstanceExport/PowerShell/InstanceExport.ps1
         shell: pwsh
+      - name: Insert Version Number (from tag)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          (Get-Content -path InstanceExport/PowerShell/InstanceExport.ps1 -Raw) -replace '-1.0.0-dev-','${{ github.ref_name }}' | Set-Content -Path InstanceExport/PowerShell/InstanceExport.ps1
+          (Get-Content -path InstanceExport/PowerShell/InstanceExport.ps1 -Raw) -replace '-githubsha-','${{ github.sha }}' | Set-Content -Path InstanceExport/PowerShell/InstanceExport.ps1
       - name: Generating code signing cert and signing InstanceExport ps script
         env:
           PFX_PWORD: ${{ secrets.PFX_PWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,15 +2,27 @@ name: CI
 run-name: ${{ github.actor }} is deploying DevResultsTools
 env:
   ARTIFACT_NAME: PowerShell.DevResultTools.InstanceExport
-on: [push]
+on:
+  - push
 jobs:
   build:
     runs-on: windows-latest
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
+      - name: Generating code signing cert and signing InstanceExport ps script
+        env:
+          PFX_PWORD: ${{ secrets.PFX_PWORD }}
+          PFX_CONTENT: ${{ secrets.BASE64_PFX_CONTENT }}
+        run: |
+          cd ./InstanceExport/PowerShell;
+          $pfxPath = Join-Path -Path ./ -ChildPath "cert.pfx";
+          $encodedBytes = [System.Convert]::FromBase64String($env:PFX_CONTENT);
+          Set-Content $pfxPath -Value $encodedBytes -AsByteStream;
+          $cert = Import-PfxCertificate -FilePath ./cert.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $PWord;
+          Set-AuthenticodeSignature InstanceExport.ps1 $cert
+        shell: pwsh
       - name: Publish artifacts
-        #if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,12 @@ jobs:
           PFX_CONTENT: ${{ secrets.BASE64_PFX_CONTENT }}
         run: |
           cd ./InstanceExport/PowerShell;
+          $PWord = $env:PFX_PWORD;
+          $Password = ConvertTo-SecureString -String $PWord -AsPlainText -Force;
           $pfxPath = Join-Path -Path ./ -ChildPath "cert.pfx";
           $encodedBytes = [System.Convert]::FromBase64String($env:PFX_CONTENT);
           Set-Content $pfxPath -Value $encodedBytes -AsByteStream;
-          $cert = Import-PfxCertificate -FilePath ./cert.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $PWord;
+          $cert = Import-PfxCertificate -FilePath ./cert.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $Password
           Set-AuthenticodeSignature InstanceExport.ps1 $cert
         shell: pwsh
       - name: Publish artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Publish artifacts
         #if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: .
+          path: ./InstanceExport/PowerShell/InstanceExport.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: CI
+run-name: ${{ github.actor }} is deploying DevResultsTools
+env:
+  ARTIFACT_NAME: PowerShell.DevResultTools.InstanceExport
+on: [push]
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v3
+      - name: Publish artifacts
+        #if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,12 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
+      - name: Insert Version Number (from sha)
+        if: startsWith(github.ref, 'refs/heads/')
+        run: |
+          (Get-Content -path InstanceExport/PowerShell/InstanceExport.ps1 -Raw) -replace '-1.0.0-dev-','1.0.0-${{ github.sha }}' | Set-Content -Path InstanceExport/PowerShell/InstanceExport.ps1
+          (Get-Content -path InstanceExport/PowerShell/InstanceExport.ps1 -Raw) -replace '-githubsha-','${{ github.sha }}' | Set-Content -Path InstanceExport/PowerShell/InstanceExport.ps1
+        shell: pwsh
       - name: Generating code signing cert and signing InstanceExport ps script
         env:
           PFX_PWORD: ${{ secrets.PFX_PWORD }}

--- a/InstanceExport/PowerShell/InstanceExport.ps1
+++ b/InstanceExport/PowerShell/InstanceExport.ps1
@@ -1,3 +1,41 @@
+<#PSScriptInfo
+
+.VERSION -1.0.0-dev-
+
+.GUID -githubsha-
+
+.AUTHOR fred@devresults.com
+
+.COMPANYNAME DevResults
+
+.COPYRIGHT
+
+.TAGS 
+
+.LICENSEURI
+
+.PROJECTURI
+
+.ICONURI
+
+.EXTERNALMODULEDEPENDENCIES 
+
+.REQUIREDSCRIPTS
+
+.EXTERNALSCRIPTDEPENDENCIES
+
+.RELEASENOTES
+
+.PRIVATEDATA
+
+#>
+
+<# 
+
+.DESCRIPTION 
+ DevResults Instance Export script 
+
+#> 
 [CmdletBinding()]
 param(    
      [Parameter(Mandatory=$True, HelpMessage='Path of manifest file')][String] $manifestFilePath,


### PR DESCRIPTION
### Solves

Asana [Update InstanceExport script to be digitally signed](https://app.asana.com/0/1203641461405586/1203703207562638/f)
When I was on-call and investigating the [8093](https://devresults.freshdesk.com/a/tickets/8093) FD ticket where the client was having issues to export their instance data in a mac. I tried to help but even with a Windows machine they were reporting seen errors. In my investigation I found that one of the problems that users could have is that our PS script is not currently digitally signed. This PR tries to cover this bit of the process so they should only be prompted to trust the script and with the signature we have in place in our script if they would like to.

### Description

I first started by NG's suggestion on taking a look what he have done for `Connectors` repo and PowerBI connector release. You can also take a look if you are curious about the steps in the #[16](https://github.com/DevResults/Connectors/pull/16) PR. I've follow the steps in my local machine to install the `DevResultsRoot` certificate and place it in the trust providers store.

Then, I've created a `New-SelfSignCertificate` with a password, used `Export-PfxCertificate` to create a `.pfx` file in my local machine and used the `[convert]::ToBase64String((Get-Content -path ".\spc.pfx" -Encoding byte))` to convert it to a base 64 string so we could add it to the repo secrets. Then, I created to secrets in the `DevResultsTools` repo one `PFX_PWORD` with the password for install the pfx and `BASE64_PFX_CONTENT` to be able to use it in the git hub actions file.

In parallel with the steps already mentioned I've created a `main.yml` file in the repo to handle the build for each commit we push in the repo. I had to perform a couple of tries before achieving the version I'm submitting here for inspection and as well my little misunderstandings about certificates were also a factor of doubting that I was going in the right direction. As a result, right now we have a ci building and publishing the artifact as a zip file named `PowerShell.DevResultTools.InstanceExport` and that brings inside only the `InstanceExport.ps1` file with a `<#PSScriptInfo` for general info and versioning of the script and a `# SIG # Begin signature block` that will be the signature for the certificate we have created. 

Please note, that in order to proper trust the signed code clients will need to perform a previous step for properly running it and they should receive a similar screen when they would like to run the script for export an Instance. I tried to describe the steps you need to do in the **How To Test** section so we can update the instructions in the repo for users be able to properly handle it themselves when they need it.

### How To Test

0 - Create a new directory in your machine
1 - Download the last build [artifact](https://github.com/DevResults/DevResultsTools/suites/10540063137/artifacts/524004154) and save it in your new directory
2 - Extract the files in the directory
3 - Open a new Power Shell terminal as an admin
4 - Run the command `Get-ExecutionPolicy`
5 - See if you get the `RemoteSigned` output
6 - If not, please run the following command `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned`
7 - Try to run the script using a PowerShell Admin terminal (prompt)
8 - See if you get the following message: 
`.\InstanceExport.ps1: File C:\InstanceExport\InstanceExport.ps1 cannot be loaded. A certificate chain could not be built to a trusted root authority..` it means that you don't have the `DevResults PowerShell Signing Certificate` certificate installed to validate the script signature
10 - Download the `DevResultsInstanceExport.cer` file on `G:\Shared Drives\Engineering\Azure Certificates`
11 - Install the certificate in your machine making sure to install it in the `Trusted Root Certificate Authorities` store choosing:
 - Current User/Local Machine
 - Choose in the next part of wizard install Place all certificates in the following store
 - Click in Browse.. button
 - Choose Trusted Root Certification Authorities
You will probably will be looking at a screen like this
![image](https://user-images.githubusercontent.com/67288628/214441983-dde23d34-39ce-4961-8c9a-47aa77048939.png)
12 - Click on Next and then on Finish to install it.
13 - Open `Certificates Manager` (certmgr) and check that the `DevResultsRoot` certificate was installed in the `Trusted Root Certification Authorities` store like the image below
![image](https://user-images.githubusercontent.com/67288628/214442757-281c9a48-63de-45b5-b111-04aa2e3edecc.png)
14 - Try to run the script again in the PowerShell terminal
15 - See if you get the following message:
 `Do you want to run software from this untrusted publisher?
File C:\InstanceExport\InstanceExport.ps1 is published by CN=DevResults PowerShell Signing Certificate and is
not trusted on your system. Only run scripts from trusted publishers.
[V] Never run  [D] Do not run  [R] Run once  [A] Always run  [?] Help (default is "D"):`
16 - Choose option `[R] Run once`
17 - Check that you are able to run the script (and get data exported for an instance if you have a manifest.json file already)
18 - Check again your  `Certificates Manager` (certmgr) and look in `Trusted Publisher`
19 - It should be empty or have already existing trusted publishers but not `DevResults PowerShell Signing Certificate`
![image](https://user-images.githubusercontent.com/67288628/214442993-365f4778-576c-4d77-9396-182f77471b13.png)
20 - Run the script again and when prompted the same question choose now option `[A] Always Run` 
21 - Check that you are able to run the script just fine (and get data exported for an instance if you have a manifest.json file already)
22 - Check again your  `Certificates Manager` (certmgr) and look in `Trusted Publisher` store and you will see the `DevResults PowerShell Signing Certificate`
![image](https://user-images.githubusercontent.com/67288628/214443430-141f5021-286f-46a6-9cda-6ef38ce0696a.png)
23 - (Optional) Get a `manifest.json` using DevResults API and export an instance data for tests. I've used `engineering` instance on my tests.

### Verifications:

**Submitter**:

- [ ] Added / Updated Test Coverage
- [ ] New tables added to `DeleteAllData` stored procedure
- [ ] Checked custom queries & setup scripts for removed/renamed tables & columns
- [ ] All strings are localized
- [ ] [All pseudonyms](https://help.devresults.com/help/renaming-terms-in-devresults) accounted for
- [ ] Assigned appropriate pull request labels

**Data Reviewer**:

- [ ] Works as described
- [ ] Tasks created for KB, RN, and client comms

**Engineer Reviewer**:

- [ ] Works as described
- [ ] Increases test coverage
- [ ] Tested for Partner regressions
- [ ] Does not leak PII through Exception Messages or Logs
- [ ] Missed refactoring opportunities?
- [ ] Tested for broader potential regressions than actual code changes might suggest
- [ ] [Clean Code](https://docs.google.com/document/d/1cv42ef3JyRdcNGx5C_17KOK7iY8aGrmiUU3OtBUmZNk/edit)?
- [ ] [Reflects engineering goals](https://github.com/DevResults/DevResults/wiki/Engineering-Goals)
