### PR TITLE
add comment about select mode

### DIFF
--- a/InstanceExport/PowerShell/README.md
+++ b/InstanceExport/PowerShell/README.md
@@ -16,7 +16,7 @@ In order to use it, you should:
 
     e.g.: `cd C:\Users\MyUser\InstanceExport`
 
-6. In the cli prompt type the following command.
+6. In the cli prompt type the following command. **Be very careful not to click inside the cli prompt while it's running, or it may go into "select mode" and pause.**
    
     `.\InstanceExport`
 


### PR DESCRIPTION
Based on incomplete script runs from at least two clients. See: [this for context](https://fitzse.wordpress.com/2013/02/04/powershell-console-select-mode/#:~:text=When%20I%20would%20click%20on%20the%20console%20window%20to%20focus%20it%20on%20the%20screen%20I%20would%20often%20accidentally%20select%20some%20empty%20space%20on%20the%20window%20which%20would%20put%20the%20console%20window%20into%20%E2%80%9CSelect%20Mode%E2%80%9D%20which%20pauses%20script%20execution.%20Nothing%20was%20wrong%20with%20my%20script.) and [this for previous issues](https://devresults.slack.com/archives/C04B0EUNU/p1643054602004200)