### PR TITLE
Adding retry mechanism for InstanceExport

### DIFF
--- a/InstanceExport/PowerShell/InstanceExport.ps1
+++ b/InstanceExport/PowerShell/InstanceExport.ps1
@@ -206,6 +206,7 @@ This function exports an given instancce and save it to your disk in the specifi
                         Log -msg "StatusCode: $($_.Exception.Response.StatusCode.value__)" -logLevel "error" -currentDate $currentDate
                         Log -msg "Url: $($entry.Url)" -logLevel "error" -currentDate $currentDate
                         Log -msg "StatusDescription: $($_.Exception.Response.StatusDescription)" -logLevel "error" -currentDate $currentDate
+                        Log -msg "Exception: $($_.Exception)" -logLevel "error" -currentDate $currentDate
                     }
                 }
                 else {

--- a/InstanceExport/PowerShell/InstanceExport.ps1
+++ b/InstanceExport/PowerShell/InstanceExport.ps1
@@ -1,13 +1,12 @@
 [CmdletBinding()]
 param(    
-     [Parameter(Mandatory=$True, HelpMessage='Path of manifest file')][String] $manifestFilePath,
-     [Parameter(Mandatory=$True, HelpMessage='Path where to create the exported files')][String] $exportFilePath,
-     [Parameter(Mandatory=$True, HelpMessage='Your username on DevResults')][String] $userName,
-     [Parameter(Mandatory=$True, HelpMessage='Your password on DevResults')][SecureString] $password,
-     [Parameter(Mandatory=$False, HelpMessage='Flag to overwrite all files that already exists')][boolean] $overwrite = $false
+    [Parameter(Mandatory = $True, HelpMessage = 'Path of manifest file')][String] $manifestFilePath,
+    [Parameter(Mandatory = $True, HelpMessage = 'Path where to create the exported files')][String] $exportFilePath,
+    [Parameter(Mandatory = $True, HelpMessage = 'Your username on DevResults')][String] $userName,
+    [Parameter(Mandatory = $True, HelpMessage = 'Your password on DevResults')][SecureString] $password,
+    [Parameter(Mandatory = $False, HelpMessage = 'Flag to overwrite all files that already exists')][boolean] $overwrite = $false
 )
-Function Write-ColorOutput($ForegroundColor)
-{
+Function Write-ColorOutput($ForegroundColor) {
     # save the current color
     $fc = $host.UI.RawUI.ForegroundColor
 
@@ -28,30 +27,29 @@ Function Write-ColorOutput($ForegroundColor)
 
 Function Log {
     param(
-        [Parameter(Mandatory=$true)][String]$msg,
-        [Parameter(Mandatory=$false)][String]$displayMsg,
-        [Parameter(Mandatory=$true)][String]$logLevel,
-        [Parameter(Mandatory=$true)][String]$currentDate
+        [Parameter(Mandatory = $true)][String]$msg,
+        [Parameter(Mandatory = $false)][String]$displayMsg,
+        [Parameter(Mandatory = $true)][String]$logLevel,
+        [Parameter(Mandatory = $true)][String]$currentDate
     )
-    switch($logLevel)
-    {
-        "error"{
-            if ($displayMsg){
+    switch ($logLevel) {
+        "error" {
+            if ($displayMsg) {
                 Write-ColorOutput red $displayMsg
             }
         }
-        "displayInfo"{
-            if ($displayMsg){
+        "displayInfo" {
+            if ($displayMsg) {
                 Write-ColorOutput yellow $displayMsg
             }
         }
-        "info"{
-            if ($displayMsg){
+        "info" {
+            if ($displayMsg) {
                 Write-Information $displayMsg
             }
         }
-        "success"{
-            if ($displayMsg){
+        "success" {
+            if ($displayMsg) {
                 Write-ColorOutput green $displayMsg
             }
         }
@@ -59,20 +57,19 @@ Function Log {
     Add-Content "$($exportFilePath)/InstanceExport_$($currentDate)_log.txt" $msg
 }
 
-Function CreateDirectoryIfDoesNotExist{
+Function CreateDirectoryIfDoesNotExist {
     param (
-        [Parameter(Mandatory=$true)][String]$directoryPath,
-        [Parameter(Mandatory=$true)][String] $currentDate
+        [Parameter(Mandatory = $true)][String]$directoryPath,
+        [Parameter(Mandatory = $true)][String] $currentDate
     )
     $directoryExists = Test-Path -Path $directoryPath
-    if (!$directoryExists)
-    {
-        try{
+    if (!$directoryExists) {
+        try {
             New-Item -Path $directoryPath -ItemType "directory" | Out-Null
             $msg = "$directoryPath created"
             Log -msg $msg -displayMsg $msg -logLevel "info" -currentDate $currentDate
         }
-        catch{ 
+        catch { 
             $msg = "Error trying to create $directoryPath directory"
             $displayMsg = "Error creating directory"
             Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate
@@ -80,7 +77,7 @@ Function CreateDirectoryIfDoesNotExist{
     }
 }
 
-Function Login(){
+Function Login() {
     $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($password)
     $UnsecurePassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
 
@@ -90,9 +87,9 @@ Function Login(){
     }
 
     $Parameters = @{
-        Method = "POST"
-        Uri = "https://$($manifestJson.SubDomain).$($manifestJson.HostName)/api/login"
-        Body = ($Body | ConvertTo-Json)
+        Method      = "POST"
+        Uri         = "https://$($manifestJson.SubDomain).$($manifestJson.HostName)/api/login"
+        Body        = ($Body | ConvertTo-Json)
         ContentType = "application/json"
     }
 
@@ -101,11 +98,11 @@ Function Login(){
     return $accessTokenResponseModel
 }
 
-Function Logout($header){
+Function Logout($header) {
     $Parameters = @{
-        Method = "POST"
-        Uri = "https://$($manifestJson.SubDomain).$($manifestJson.HostName)/api/logout"
-        Headers = $header
+        Method      = "POST"
+        Uri         = "https://$($manifestJson.SubDomain).$($manifestJson.HostName)/api/logout"
+        Headers     = $header
         ContentType = "application/json"
     }
 
@@ -113,9 +110,8 @@ Function Logout($header){
     
 }
 
-function Export
-{
-<#
+function Export {
+    <#
 .Description
 This function exports an given instancce and save it to your disk in the specified exportFilePath from a JSON manifest file
 #>    
@@ -123,33 +119,32 @@ This function exports an given instancce and save it to your disk in the specifi
 
     $manifestFileExists = Test-Path -Path $manifestFilePath
 
-    if ($manifestFileExists)
-    {
+    if ($manifestFileExists) {
         $manifestJson = Get-Content -Raw -Path $manifestFilePath | ConvertFrom-Json
-        if ($manifestJson.CreateDate){
+        if ($manifestJson.CreateDate) {
             $currentDate = Get-Date $manifestJson.CreateDate -Format "MM_dd_yyyy_HH_mm_ss"
         }
-        else{
+        else {
             $msg = "Error in reading manifest file"
             $displayMsg = "An error occurred when reading manifest file"
             Log -msg $msg -displayMsg $displayMsg -logLevel "error"  -currentDate $currentDate
             Exit 1
         }
     
-        try{
+        try {
             CreateDirectoryIfDoesNotExist -directoryPath $exportFilePath -currentDate $currentDate
         }
-        catch{
+        catch {
             $msg = "Error trying to create $directoryPath directory"
             $displayMsg = "An error occurred when trying to create a new directory"
             Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate
             Exit 1
         }
 
-        try{
+        try {
             $accessTokenResponseModel = Login
         }
-        catch{
+        catch {
             Log -msg "An error occurred" -displayMsg "$($_.Exception.Response.StatusCode.value__): An error occurred when logging in" -logLevel "error" -currentDate $currentDate
             Log -msg "Authorization error for Instance Export" -logLevel "error" -currentDate $currentDate
             Log -msg "StatusCode: $($_.Exception.Response.StatusCode.value__)" -logLevel "error" -currentDate $currentDate
@@ -157,7 +152,7 @@ This function exports an given instancce and save it to your disk in the specifi
             Log -msg "StatusDescription: $($_.Exception.Response.StatusDescription)" -logLevel "error" -currentDate $currentDate
         }
 
-        if ($accessTokenResponseModel){
+        if ($accessTokenResponseModel) {
 
             $accessToken = $accessTokenResponseModel.access_token
 
@@ -166,10 +161,8 @@ This function exports an given instancce and save it to your disk in the specifi
             }
 
             $currentCategory = "";
-            foreach ($entry in $manifestJson.Entries)
-            {
-                if ($currentCategory -ne $entry.Category)
-                {
+            foreach ($entry in $manifestJson.Entries) {
+                if ($currentCategory -ne $entry.Category) {
                     $currentCategory = $entry.Category;
                     $message = "Starting extraction of $($entry.Category) category."
                     Log -msg $message -displayMsg $message -logLevel "displayInfo" -currentDate $currentDate
@@ -178,10 +171,10 @@ This function exports an given instancce and save it to your disk in the specifi
                 Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate
                 $directoryPath = $exportFilePath + "/" + $entry.Path
             
-                try{
+                try {
                     CreateDirectoryIfDoesNotExist -directoryPath $directoryPath -currentDate $currentDate
                 }
-                catch{
+                catch {
                     $msg = "Error trying to create $directoryPath directory"
                     $displayMsg = "An error occurred when trying to create a new directory"
                     Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate
@@ -189,8 +182,7 @@ This function exports an given instancce and save it to your disk in the specifi
                 $fileName = $entry.FileName.Split([IO.Path]::GetInvalidFileNameChars()) -join ''
                 $filePath = "$directoryPath/$fileName"
                 $fileAlreadyExists = Test-Path -Path $filePath -PathType Leaf
-                if (!$fileAlreadyExists -or $overwrite)
-                {
+                if (!$fileAlreadyExists -or $overwrite) {
                     $entryExportParameters = @{
                         Method      = "GET"
                         Uri         = "https://$($manifestJson.SubDomain).$($manifestJson.HostName)$($entry.Url)"
@@ -198,16 +190,16 @@ This function exports an given instancce and save it to your disk in the specifi
                         ContentType = "application/json"  
                     }
                         
-                    try{
-                        if (!$entry.fileName.Contains(".json")){
+                    try {
+                        if (!$entry.fileName.Contains(".json")) {
                             Invoke-RestMethod @entryExportParameters -OutFile $filePath | Out-Null
                         }
-                        else{
+                        else {
                             $GetEntriesResponse = Invoke-RestMethod @entryExportParameters
                             $GetEntriesResponse | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath
                         }
                     }
-                    catch{
+                    catch {
                         $message = "Error occurred when extracting data from $($entry.Url)"
                         Log -msg "An error occurred" -displayMsg $message -logLevel "error" -currentDate $currentDate
                         Log -msg $message -logLevel "error" -currentDate $currentDate
@@ -216,7 +208,7 @@ This function exports an given instancce and save it to your disk in the specifi
                         Log -msg "StatusDescription: $($_.Exception.Response.StatusDescription)" -logLevel "error" -currentDate $currentDate
                     }
                 }
-                else{
+                else {
                     $message = "Skipping $filePath because file already exists"
                     Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate
                 }
@@ -224,25 +216,26 @@ This function exports an given instancce and save it to your disk in the specifi
             $msg = "Exporting Instance run finished."
             Log -msg $msg -displayMsg $msg -logLevel "success" -currentDate $currentDate
 
-            try{
+            try {
                 Logout($header)
-            } catch{
+            }
+            catch {
                 $message = "Error occurred when logging out"
                 Log -msg $message -displayMsg $message -logLevel "error" -currentDate $currentDate
             }
         }
-        else{
+        else {
             $msg = "Exporting Instance run finished with errors."
             $displayMsg = "Exporting Instance run was not successful. Check the log file for more details."
             Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate
         }
         
     }
-    else{
-        try{
+    else {
+        try {
             CreateDirectoryIfDoesNotExist -directoryPath $exportFilePath -currentDate $currentDate
         }
-        catch{
+        catch {
             $displayMsg = "An error occurred when trying to create a new directory"
             Log -msg "Error trying to create $directoryPath directory" -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate
         }


### PR DESCRIPTION
### Solves

FD [Instance Export Manifest](https://devresults.freshdesk.com/a/tickets/8201) 

Our clients on `gec` were trying to use the instance export and a few documents were not being downloaded by the script run because a range of errors that I'll be adding to a troubleshot section in the documentation later on. From the investigation on logs I've found that a few times we get an log error in the following format:

```
An error occurred
Error occurred when extracting data from /api/awards/12344/documents/ProjecT/ProjectT Q08 Approval Docs/Karibean Cluster/%239001 Example/02 Indicator Monitoring Findings/9001-Example-Q8-Monitoring-Report---Final.docx
StatusCode: 503
Url: /api/awards/12344/documents/ProjecT/ProjectT Q08 Approval Docs/Karibean Cluster/%239001 Example/02 Indicator Monitoring Findings/9001-Example-Q8-Monitoring-Report---Final.docx
StatusDescription: Service Unavailable
```

This PR updates the `InstanceExport` script to pause the execution while the site is offline, which can happen in case we are deploying new features to the site or if there is a hiccup in Azure app service. This should avoid logging a bunch of errors in the log file and reduce noise for users.

### Description

I took a peak in solving the issue for the case we try to run any export try and for some reason the server is not available at the moment. This may be caused if we are deploying a new feature using `Github` actions or if there is any hiccup in Azure app service that temporarily make the api unavailable to respond and get the data to be exported.

In my investigations in log files for fresh desk ticket I've found that some errors didn't had a Status code and there is no evidence of what may have been wrong. So, I added a extra log in the `catch` block to also log the Exception itself, so we can see what happened for those cases. Also from this investigation, I was able to notice that if the path is too long, the `Windows Power Shell` using PS 5 version is throwing an exception ` System.IO.DirectoryNotFoundException: Could not find a part of the path` but this can be workaround if users use PowerShell 7 (x64).

Then, I focused the work on solving the issue of getting `503` responses which means that site and api were unavailable and we have tried and couldn't download the file. Since we don't pause the script a bunch of files were not download and they could have been if api was available. An alternative would be clients to run the script again too, so the script would skip already existent files and try again the ones that got `503` but the clients in general don't know about that. That's why I'm going to add this in a `Troubleshot` section in the repo later on. 

In order to fix the problem, I've created a `ServerHealthCheck` function that will be called if we got an `503` response in the `catch` block and this will be in a loop till the server is back. Also, I've changed a bit how the external loop logic for `$manifestJson.entries`. Before, it was using a `foreach($entry in $manifestJson.Entries)` and now I'm using an index var `$i` so we can stop at a given index and retry it again when the server is back. Like that we will "pause" the script tries until the service is back, available and ready to respond properly.

### How To Test

0 - Open `DevResults` project on `main` branch
1 - Make sure you build the site and run it
2 - Open a local site and upload a document to an activity for example
3 - Open the API and get a manifest file to that local instance
4 - Go to `DevResultsTools` repo and copy the `InstanceExport.ps1` from the `add-retry-mechanism` branch
5 - Save the `InstanceExport` script in a folder in your machine
6 - Open a `PowerShell` window. Here I recommend that you use PowerShell 7 but it might work if you use `Windows Power Shell` too
7 - Navigate to the directory you've saved the `InstanceExport` script
8 - Before running the script, go to `DevResults` project and add two breakpoints:

- One in line 156 on `DocumentsController` in the `Download` method
- Other in line 9 of `HealthCheck.aspx.vb` in the `Page_Init` method

9 - Trigger the export using `.\InstanceExport`
10 - When the first breakpoint is hit, change the code and add this after line 161
```
response.StatusCode = HttpStatusCode.ServiceUnavailable;
return response;

```
11 - Press F5 to continue
12 - This will redirect you to the `HealthCheck` breakpoint which means that we simulate a server being unavailable
13 - Here you can stop the Debug session on `DevResults`  project and you can check that the `InstanceExport` script is still running and paused
14 - Now, go back to `Download` method in `DocumentsController` and remove the recently added two lines from step 10
15 - Start again `DevResults` project
16 - Expect that the `HealthCheck`  breakpoint is hit again. Then press F5 to continue
17 - Expect that the `Download`  breakpoint is hit again and you can now download the file successfully.
18 - You can remove breakpoints now and let the process continue till the end and inspect the logs.
19 - You should probably see only one `503` response in your log and can see a entry similar to this:

```
Extracting data from /api/documents/test document.docx
export-local/documents created
An error occurred
Error occurred when extracting data from /api/documents/test document.docx
StatusCode: 503
Url: /api/documents/test document.docx
StatusDescription: 
Exception: Microsoft.PowerShell.Commands.HttpResponseException: Response status code does not indicate success: 503 (Service Unavailable).
   at System.Management.Automation.MshCommandRuntime.ThrowTerminatingError(ErrorRecord errorRecord)
Server is offline. Waiting it to get back.
Server is back online
Extracting data from /api/documents/test document.docx
```
### Verifications:

**Submitter**:

- [x] Assigned appropriate pull request labels

**Data Reviewer**:

- [ ] Works as described
- [ ] Tasks created for KB, RN, and client comms

**Engineer Reviewer**:

- [ ] Works as described
- [ ] Missed refactoring opportunities?
- [ ] [Clean Code](https://docs.google.com/document/d/1cv42ef3JyRdcNGx5C_17KOK7iY8aGrmiUU3OtBUmZNk/edit)?
- [ ] [Reflects engineering goals](https://github.com/DevResults/DevResults/wiki/Engineering-Goals)
