### PR TITLE
Improve how the $password is converted to plain text

### DIFF
--- a/InstanceExport/PowerShell/InstanceExport.ps1
+++ b/InstanceExport/PowerShell/InstanceExport.ps1
@@ -116,8 +116,7 @@ Function CreateDirectoryIfDoesNotExist {
 }
 
 Function Login() {
-    $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($password)
-    $UnsecurePassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+    $UnsecurePassword = ConvertFrom-SecureString -SecureString $password -AsPlainText
 
     $Body = @{
         UserName = $userName


### PR DESCRIPTION
### Solves

FD: https://helpdesk.devresults.com/a/tickets/9494

A client reported getting the following error: `401: An error occurred when logging in`

This turned out to be a "wrong password" response coming from the server because the `$password` parameter was not properly being converted back to a plain text string on non-Window environments.

### Description

It seems that the previous technique was only returning the first character when running the script from on non-Windows environments. I've replaced our previous conversion of `$password` with [ConvertFrom-SecureString](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/convertfrom-securestring?view=powershell-7.4#example-4-convert-a-secure-string-directly-to-a-plaintext-string), which seems to work properly.

### Testing

1. Create an instance export manifest
2. Run `InstanceExport.ps1` with the manifest and verify that the login still works (on Windows and/or another OS)