### PR TITLE
Improve Export Script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,12 @@ jobs:
           $cert = Import-PfxCertificate -FilePath ./cert.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $Password
           Set-AuthenticodeSignature InstanceExport.ps1 $cert
         shell: pwsh
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ./InstanceExport/PowerShell/InstanceExport.ps1
+          generateReleaseNotes: true
       - name: Publish artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           artifacts: ./InstanceExport/PowerShell/InstanceExport.ps1
           generateReleaseNotes: true
       - name: Publish artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ./InstanceExport/PowerShell/InstanceExport.ps1


### PR DESCRIPTION
We've had tickets on two things recently:
1. script no longer works on powershell 5
2. script is unsigned

For problem 1, this builds on #9 by trying both ways to get the password in plain text. If neither of those work, we fall back to prompting for a plain text string... end result is folks shouldn't be blocked from logging in by their powershell version/environment

For problem 2, this builds on #4 by publishing the signed script as a release (instead of an artifact). Releases are generally easier to find, and are retained longer (artifacts are for only 90 days)

To test:
1. create a manifest
2. run the export script in powershell 5
3. run the export script in powershell 7
4. if you've got an environment where #9 was a fix, run the export script there

If that all works and seems nice, we'll tag and generate a release for further testing