### PR TITLE
Instance Export: Fix script signing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,14 +25,22 @@ jobs:
         env:
           PFX_PWORD: ${{ secrets.PFX_PWORD }}
           PFX_CONTENT: ${{ secrets.BASE64_PFX_CONTENT }}
+          ROOT_CONTENT: ${{ secrets.BASE64_ROOT_CONTENT }}
         run: |
           cd ./InstanceExport/PowerShell;
+
+          $rootPath = Join-Path -Path ./ -ChildPath "root.cer";
+          $encodedBytes = [System.Convert]::FromBase64String($env:ROOT_CONTENT);
+          Set-Content $rootPath -Value $encodedBytes -AsByteStream;
+          Import-Certificate -FilePath ./root.cer -CertStoreLocation Cert:\LocalMachine\Root
+
           $PWord = $env:PFX_PWORD;
           $Password = ConvertTo-SecureString -String $PWord -AsPlainText -Force;
           $pfxPath = Join-Path -Path ./ -ChildPath "cert.pfx";
           $encodedBytes = [System.Convert]::FromBase64String($env:PFX_CONTENT);
           Set-Content $pfxPath -Value $encodedBytes -AsByteStream;
           $cert = Import-PfxCertificate -FilePath ./cert.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $Password
+
           $sig = Set-AuthenticodeSignature InstanceExport.ps1 $cert -ErrorAction Stop
           if ($sig.Status -ne 'Valid') { throw $sig.StatusMessage }
         shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           $encodedBytes = [System.Convert]::FromBase64String($env:PFX_CONTENT);
           Set-Content $pfxPath -Value $encodedBytes -AsByteStream;
           $cert = Import-PfxCertificate -FilePath ./cert.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $Password
-          Set-AuthenticodeSignature InstanceExport.ps1 $cert
+          Set-AuthenticodeSignature InstanceExport.ps1 $cert -ErrorAction Stop
         shell: pwsh
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,8 @@ jobs:
           $encodedBytes = [System.Convert]::FromBase64String($env:PFX_CONTENT);
           Set-Content $pfxPath -Value $encodedBytes -AsByteStream;
           $cert = Import-PfxCertificate -FilePath ./cert.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $Password
-          Set-AuthenticodeSignature InstanceExport.ps1 $cert -ErrorAction Stop
+          $sig = Set-AuthenticodeSignature InstanceExport.ps1 $cert -ErrorAction Stop
+          if ($sig.Status -ne 'Valid') { throw $sig.StatusMessage }
         shell: pwsh
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/InstanceExport/PowerShell/README.md
+++ b/InstanceExport/PowerShell/README.md
@@ -4,7 +4,7 @@ At DevResults we value the concept that your data belongs to _you_, and you have
 
 In order to use it, you should:
 
-1. Download the [InstanceExport.ps1](https://raw.githubusercontent.com/DevResults/DevResultsTools/main/InstanceExport/PowerShell/InstanceExport.ps1) PowerShell script available in this repo to your machine. One way to do this is to right click the link to the file name in the previous sentence and choose "Save link as..." to produce a save dialog box.
+1. Download the [InstanceExport.ps1](https://github.com/DevResults/DevResultsTools/releases/download/1.0.2/InstanceExport.ps1) PowerShell script.
 
 2. Reach out to us at help@devresults.com to request an Instance Export Manifest.
 


### PR DESCRIPTION
The code signing certificate was out of date, but CI didn't tell us that signing wasn't working. So I made some changes to the signing script so that it fails if the resulting signature isn't valid. This requires the DevResultsRoot certificate to be a trusted root certificate, so I added that to the repository secrets and CI file as well. Then I created a new signing certificate and put that in the secrets and Google drive

You can see that CI works on https://github.com/DevResults/DevResultsTools/actions/runs/13662472413/job/38196556984 (and you can see other previous runs failed when not everything was correctly in place)

To test, you can download the artifact from the latest run, unzip it, and confirm the signature is valid with ` Get-AuthenticodeSignature .\InstanceExport.ps1`. This will only return valid if you've also installed the DevResultsRoot certificate into your "trusted root certificates". The cer file is in google drive https://drive.google.com/file/d/1-0M8SW_Y-b4C2GPhe_OauTmwnBINop3T/view?usp=drive_link if you need it.

I also updated the README to point to the signed script (stored in a release) but that link will only be valid once we merge this and tag a new release -- there's not a good way to point to files in the most recent release (the best I can do is point to the latest release where folks can choose the file, but a direct link from the README seemed kinder)