### PR TITLE
Enabling export of multiple instances

### DIFF
--- a/InstanceExport/PowerShell/InstanceExport.ps1
+++ b/InstanceExport/PowerShell/InstanceExport.ps1
@@ -68,8 +68,7 @@ Function Log {
         [Parameter(Mandatory = $true)][String]$msg,
         [Parameter(Mandatory = $false)][String]$displayMsg,
         [Parameter(Mandatory = $true)][String]$logLevel,
-        [Parameter(Mandatory = $true)][String]$currentDate,
-        [Parameter(Mandatory = $true)][String]$instance
+        [Parameter(Mandatory = $true)][String]$currentDate
     )
     switch ($logLevel) {
         "error" {
@@ -93,26 +92,25 @@ Function Log {
             }
         }
     }
-    Add-Content "$($exportFilePath)/$instance/$($instance)_InstanceExport_$($currentDate)_log.txt" $msg
+    Add-Content "$($exportFilePath)/InstanceExport_$($currentDate)_log.txt" $msg
 }
 
 Function CreateDirectoryIfDoesNotExist {
     param (
         [Parameter(Mandatory = $true)][String]$directoryPath,
-        [Parameter(Mandatory = $true)][String] $currentDate,
-        [Parameter(Mandatory = $true)][String] $instance
+        [Parameter(Mandatory = $true)][String] $currentDate
     )
     $directoryExists = Test-Path -Path $directoryPath
     if (!$directoryExists) {
         try {
             New-Item -Path $directoryPath -ItemType "directory" | Out-Null
             $msg = "$directoryPath created"
-            Log -msg $msg -displayMsg $msg -logLevel "info" -currentDate $currentDate -instance $instance
+            Log -msg $msg -displayMsg $msg -logLevel "info" -currentDate $currentDate 
         }
         catch { 
             $msg = "Error trying to create $directoryPath directory"
             $displayMsg = "Error creating directory"
-            Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate -instance $instance
+            Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate
         }
     }
 }
@@ -123,7 +121,7 @@ Function GetPassword() {
         return ConvertFrom-SecureString -SecureString $password -AsPlainText
     }
     catch {
-        Log -msg $_.Exception.Message -logLevel "displayInfo" -currentDate $currentDate -instance $instance
+        Log -msg $_.Exception.Message -logLevel "displayInfo" -currentDate $currentDate 
     }
     # fallback to powershell 5
     $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($password)
@@ -133,7 +131,7 @@ Function GetPassword() {
     }
     # we're probably on some non-windows environment... fall back to unsecured
     $msg = "Warning: Unable to handle password securely. Falling back to plain text password"
-    Log -msg $msg -logLevel "displayInfo" -currentDate $currentDate -instance $instance
+    Log -msg $msg -logLevel "displayInfo" -currentDate $currentDate 
     return Read-Host "$msg. To continue, please enter the password again"
 }
 
@@ -192,159 +190,308 @@ This function exports an given instancce and save it to your disk in the specifi
 	
     $manifestFilePathExists = Test-Path -Path $manifestFilePath
 	
+    $target = Get-Item $manifestFilePath
+	
     if ($manifestFilePathExists) {
-        $manifestFilePath = $manifestFilePath.TrimEnd('\')  # Trim any trailing backslash if it exists
+        if (!$target.PSIsContainer) {
+            $manifestJson = Get-Content -Raw -Path $manifestFilePath | ConvertFrom-Json
+            $instance = $manifestJson.subdomain
+			
+            if ($manifestJson.CreateDate) {
+                $currentDate = Get-Date $manifestJson.CreateDate -Format "MM_dd_yyyy_HH_mm_ss"
+            }
+            else {
+                $msg = "Error in reading manifest file"
+                $displayMsg = "An error occurred when reading manifest file"
+                Log -msg $msg -displayMsg $displayMsg -logLevel "error"  -currentDate $currentDate
+                Exit 1
+            }
 		
-        $manifesJsonFiles = Get-ChildItem -Path "$manifestFilePath\*" -Include "*.json"
-		
-        foreach ($manifestFile in $manifesJsonFiles) {
-			
-            $manifestFileExists = Test-Path -Path $manifestFile
-			
-            $instance = ($manifestFile.BaseName -split ' ')[0]
-			
-            if ($manifestFileExists) {
-                $manifestJson = Get-Content -Raw -Path $manifestFile | ConvertFrom-Json
-                if ($manifestJson.CreateDate) {
-                    $currentDate = Get-Date $manifestJson.CreateDate -Format "MM_dd_yyyy_HH_mm_ss"
-                }
-                else {
-                    $msg = "Error in reading manifest file"
-                    $displayMsg = "An error occurred when reading manifest file"
-                    Log -msg $msg -displayMsg $displayMsg -logLevel "error"  -currentDate $currentDate -instance $instance
-                    Exit 1
-                }
-				
-                try {
-                    CreateDirectoryIfDoesNotExist -directoryPath "$exportFilePath\$instance" -currentDate $currentDate -instance $instance
-                }
-                catch {
-                    $msg = "Error trying to create $directoryPath directory"
-                    $displayMsg = "An error occurred when trying to create a new directory"
-                    Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate -instance $instance
-                    Exit 1
+            $directoryPath = $exportFilePath + "/" + $instance
+            try {
+                CreateDirectoryIfDoesNotExist -directoryPath $directoryPath -currentDate $currentDate
+            }
+            catch {
+                $msg = "Error trying to create $directoryPath directory"
+                $displayMsg = "An error occurred when trying to create a new directory"
+                Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate
+                Exit 1
+            }
+
+            try {
+                $accessTokenResponseModel = Login
+            }
+            catch {
+                Log -msg "An error occurred" -displayMsg "$($_.Exception.Response.StatusCode.value__): An error occurred when logging in" -logLevel "error" -currentDate $currentDate
+                Log -msg "Authorization error for Instance Export" -logLevel "error" -currentDate $currentDate 
+                Log -msg "StatusCode: $($_.Exception.Response.StatusCode.value__)" -logLevel "error" -currentDate $currentDate
+                Log -msg "Url: api/login" -logLevel "error" -currentDate $currentDate 
+                Log -msg "StatusDescription: $($_.Exception.Response.StatusDescription)" -logLevel "error" -currentDate $currentDate 
+            }
+
+            if ($accessTokenResponseModel) {
+
+                $accessToken = $accessTokenResponseModel.access_token
+
+                $header = @{
+                    "authorization" = "Bearer $accessToken"
                 }
 				
                 $msg = "$instance"
                 $displayMsg = "Starting exporting data for instance $instance"
-                Log -msg $msg -displayMsg $displayMsg -logLevel "success" -currentDate $currentDate -instance $instance
+                Log -msg $msg -displayMsg $displayMsg -logLevel "success" -currentDate $currentDate 
+
+                $currentCategory = "";
+                $i = 0;
+                for (; $i -lt $manifestJson.Entries.Length; $i = $i + 1) {
+                    $entry = $manifestJson.Entries[$i]
+                    if ($currentCategory -ne $entry.Category) {
+                        $currentCategory = $entry.Category;
+                        $message = "Starting extraction of $($entry.Category) category."
+                        Log -msg $message -displayMsg $message -logLevel "displayInfo" -currentDate $currentDate 
+                    }
+                    $message = "Extracting data from $($entry.Url)"
+                    Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate 
+                    $directoryPath = $exportFilePath + "/" + $instance + "/" + $entry.Path
+				
+                    try {
+                        CreateDirectoryIfDoesNotExist -directoryPath $directoryPath -currentDate $currentDate 
+                    }
+                    catch {
+                        $msg = "Error trying to create $directoryPath directory"
+                        $displayMsg = "An error occurred when trying to create a new directory"
+                        Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate 
+                    }
+                    $fileName = $entry.FileName.Split([IO.Path]::GetInvalidFileNameChars()) -join ''
+                    $filePath = "$directoryPath/$fileName"
+                    $fileAlreadyExists = Test-Path -Path $filePath -PathType Leaf
+                    if (!$fileAlreadyExists -or $overwrite) {
+                        $entryExportParameters = @{
+                            Method      = "GET"
+                            Uri         = "https://$($manifestJson.SubDomain).$($manifestJson.HostName)$($entry.Url)"
+                            Headers     = $header
+                            ContentType = "application/json"  
+                        }
+							
+                        try {
+                            if (!$entry.fileName.Contains(".json")) {
+                                Invoke-RestMethod @entryExportParameters -OutFile $filePath | Out-Null
+                            }
+                            else {
+                                $GetEntriesResponse = Invoke-RestMethod @entryExportParameters
+                                $GetEntriesResponse | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath
+                            }
+                        }
+                        catch {
+                            $message = "Error occurred when extracting data from $($entry.Url)"
+                            Log -msg "An error occurred" -displayMsg $message -logLevel "error" -currentDate $currentDate 
+                            Log -msg $message -logLevel "error" -currentDate $currentDate 
+                            Log -msg "StatusCode: $($_.Exception.Response.StatusCode.value__)" -logLevel "error" -currentDate $currentDate 
+                            Log -msg "Url: $($entry.Url)" -logLevel "error" -currentDate $currentDate 
+                            Log -msg "StatusDescription: $($_.Exception.Response.StatusDescription)" -logLevel "error" -currentDate $currentDate 
+                            Log -msg "Exception: $($_.Exception)" -logLevel "error" -currentDate $currentDate 
+                            Write-Verbose $_.Exception
+                            Write-Verbose $_.Exception.Response
+                            if ($_.Exception.Response.StatusCode -eq 503) {
+                                $message = "Lost connection to server. Waiting to restablish connection."
+                                Write-ColorOutput red $message
+                                Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate 
+                                do {
+                                    $response = ServerHealtCheck("https://$($manifestJson.SubDomain).$($manifestJson.HostName)/en/healthcheck");
+									
+                                } while ($response.Exception)
+                                $message = "Server connection reestablished. Resuming export"
+                                Write-ColorOutput green $message
+                                Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate 
+                                $i = $i - 1;
+                            }
+                        }
+                    }
+                    else {
+                        $message = "Skipping $filePath because file already exists"
+                        Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate 
+                    }
+                }
+                $msg = "Exporting Instance run finished."
+                Log -msg $msg -displayMsg $msg -logLevel "success" -currentDate $currentDate 
 
                 try {
-                    $accessTokenResponseModel = Login
+                    Logout($header)
                 }
                 catch {
-                    Log -msg "An error occurred" -displayMsg "$($_.Exception.Response.StatusCode.value__): An error occurred when logging in" -logLevel "error" -currentDate $currentDate -instance $instance
-                    Log -msg "Authorization error for Instance Export" -logLevel "error" -currentDate $currentDate -instance $instance
-                    Log -msg "StatusCode: $($_.Exception.Response.StatusCode.value__)" -logLevel "error" -currentDate $currentDate -instance $instance
-                    Log -msg "Url: api/login" -logLevel "error" -currentDate $currentDate -instance $instance
-                    Log -msg "StatusDescription: $($_.Exception.Response.StatusDescription)" -logLevel "error" -currentDate $currentDate -instance $instance
+                    $message = "Error occurred when logging out"
+                    Log -msg $message -displayMsg $message -logLevel "error" -currentDate $currentDate 
                 }
-
-                if ($accessTokenResponseModel) {
-
-                    $accessToken = $accessTokenResponseModel.access_token
-
-                    $header = @{
-                        "authorization" = "Bearer $accessToken"
-                    }
-
-                    $currentCategory = "";
-                    $i = 0;
-                    for (; $i -lt $manifestJson.Entries.Length; $i = $i + 1) {
-                        $entry = $manifestJson.Entries[$i]
-                        if ($currentCategory -ne $entry.Category) {
-                            $currentCategory = $entry.Category;
-                            $message = "Starting extraction of $($entry.Category) category."
-                            Log -msg $message -displayMsg $message -logLevel "displayInfo" -currentDate $currentDate -instance $instance
-                        }
-                        $message = "Extracting data from $($entry.Url)"
-                        Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate -instance $instance
-                        $directoryPath = $exportFilePath + "/" + $instance + "/" + $entry.Path
+            }
+            else {
+                $msg = "Exporting Instance run finished with errors."
+                $displayMsg = "Exporting Instance run was not successful. Check the log file for more details."
+                Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate 
+            }
+        }
+        else { 
+            $manifestFilePath = $manifestFilePath.TrimEnd('\')  # Trim any trailing backslash if it exists
+		
+            $manifestJsonFiles = Get-ChildItem -Path "$manifestFilePath\*" -Include "*.json"
+		
+            try {
+                CreateDirectoryIfDoesNotExist -directoryPath "$exportFilePath" -currentDate $currentDate
+            }
+            catch {
+                $msg = "Error trying to create $directoryPath directory"
+                $displayMsg = "An error occurred when trying to create a new directory"
+                Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate 
+                Exit 1
+            }
+			
+            if ($manifestJsonFiles) {	
+				
+                foreach ($manifestFile in $manifestJsonFiles) {
 					
+                    $manifestFileExists = Test-Path -Path $manifestFile
+			
+                    if ($manifestFileExists) {
+                        $manifestJson = Get-Content -Raw -Path $manifestFile | ConvertFrom-Json
+				
+                        $instance = $manifestJson.subdomain
+				
                         try {
-                            CreateDirectoryIfDoesNotExist -directoryPath $directoryPath -currentDate $currentDate -instance $instance
+                            CreateDirectoryIfDoesNotExist -directoryPath "$exportFilePath\$instance" -currentDate $currentDate 
                         }
                         catch {
                             $msg = "Error trying to create $directoryPath directory"
                             $displayMsg = "An error occurred when trying to create a new directory"
-                            Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate -instance $instance
+                            Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate 
+                            Exit 1
                         }
-                        $fileName = $entry.FileName.Split([IO.Path]::GetInvalidFileNameChars()) -join ''
-                        $filePath = "$directoryPath/$fileName"
-                        $fileAlreadyExists = Test-Path -Path $filePath -PathType Leaf
-                        if (!$fileAlreadyExists -or $overwrite) {
-                            $entryExportParameters = @{
-                                Method      = "GET"
-                                Uri         = "https://$($manifestJson.SubDomain).$($manifestJson.HostName)$($entry.Url)"
-                                Headers     = $header
-                                ContentType = "application/json"  
+
+                        try {
+                            $accessTokenResponseModel = Login
+                        }
+                        catch {
+                            Log -msg "An error occurred" -displayMsg "$($_.Exception.Response.StatusCode.value__): An error occurred when logging in" -logLevel "error" -currentDate $currentDate 
+                            Log -msg "Authorization error for Instance Export" -logLevel "error" -currentDate $currentDate 
+                            Log -msg "StatusCode: $($_.Exception.Response.StatusCode.value__)" -logLevel "error" -currentDate $currentDate 
+                            Log -msg "Url: api/login" -logLevel "error" -currentDate $currentDate 
+                            Log -msg "StatusDescription: $($_.Exception.Response.StatusDescription)" -logLevel "error" -currentDate $currentDate 
+                        }
+
+                        if ($accessTokenResponseModel) {
+
+                            $accessToken = $accessTokenResponseModel.access_token
+
+                            $header = @{
+                                "authorization" = "Bearer $accessToken"
                             }
+					
+                            $message = "Starting exporting data for instance $instance"
+                            Log -msg $message -displayMsg $message -logLevel "success" -currentDate $currentDate 
+
+                            $currentCategory = "";
+                            $i = 0;
+                            for (; $i -lt $manifestJson.Entries.Length; $i = $i + 1) {
+                                $entry = $manifestJson.Entries[$i]
+                                if ($currentCategory -ne $entry.Category) {
+                                    $currentCategory = $entry.Category;
+                                    $message = "Starting extraction of $($entry.Category) category."
+                                    Log -msg $message -displayMsg $message -logLevel "displayInfo" -currentDate $currentDate 
+                                }
+                                $message = "Extracting data from $($entry.Url)"
+                                Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate 
+                                $directoryPath = $exportFilePath + "/" + $instance + "/" + $entry.Path
 								
-                            try {
-                                if (!$entry.fileName.Contains(".json")) {
-                                    Invoke-RestMethod @entryExportParameters -OutFile $filePath | Out-Null
+                                try {
+                                    CreateDirectoryIfDoesNotExist -directoryPath $directoryPath -currentDate $currentDate 
+                                }
+                                catch {
+                                    $msg = "Error trying to create $directoryPath directory"
+                                    $displayMsg = "An error occurred when trying to create a new directory"
+                                    Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate 
+                                }
+                                $fileName = $entry.FileName.Split([IO.Path]::GetInvalidFileNameChars()) -join ''
+                                $filePath = "$directoryPath/$fileName"
+                                $fileAlreadyExists = Test-Path -Path $filePath -PathType Leaf
+                                if (!$fileAlreadyExists -or $overwrite) {
+                                    $entryExportParameters = @{
+                                        Method      = "GET"
+                                        Uri         = "https://$($manifestJson.SubDomain).$($manifestJson.HostName)$($entry.Url)"
+                                        Headers     = $header
+                                        ContentType = "application/json"  
+                                    }
+								
+                                    try {
+                                        if (!$entry.fileName.Contains(".json")) {
+                                            Invoke-RestMethod @entryExportParameters -OutFile $filePath | Out-Null
+                                        }
+                                        else {
+                                            $GetEntriesResponse = Invoke-RestMethod @entryExportParameters
+                                            $GetEntriesResponse | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath
+                                        }
+                                    }
+                                    catch {
+                                        $message = "Error occurred when extracting data from $($entry.Url)"
+                                        Log -msg "An error occurred" -displayMsg $message -logLevel "error" -currentDate $currentDate 
+                                        Log -msg $message -logLevel "error" -currentDate $currentDate 
+                                        Log -msg "StatusCode: $($_.Exception.Response.StatusCode.value__)" -logLevel "error" -currentDate $currentDate 
+                                        Log -msg "Url: $($entry.Url)" -logLevel "error" -currentDate $currentDate 
+                                        Log -msg "StatusDescription: $($_.Exception.Response.StatusDescription)" -logLevel "error" -currentDate $currentDate 
+                                        Log -msg "Exception: $($_.Exception)" -logLevel "error" -currentDate $currentDate 
+                                        Write-Verbose $_.Exception
+                                        Write-Verbose $_.Exception.Response
+                                        if ($_.Exception.Response.StatusCode -eq 503) {
+                                            $message = "Lost connection to server. Waiting to restablish connection."
+                                            Write-ColorOutput red $message
+                                            Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate
+                                            do {
+                                                $response = ServerHealtCheck("https://$($manifestJson.SubDomain).$($manifestJson.HostName)/en/healthcheck");
+                                            } while ($response.Exception)
+                                            $message = "Server connection reestablished. Resuming export"
+                                            Write-ColorOutput green $message
+                                            Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate
+                                            $i = $i - 1;
+                                        }
+                                    }
                                 }
                                 else {
-                                    $GetEntriesResponse = Invoke-RestMethod @entryExportParameters
-                                    $GetEntriesResponse | ConvertTo-Json -Depth 100 | Out-File -FilePath $filePath
+                                    $message = "Skipping $filePath because file already exists"
+                                    Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate 
                                 }
                             }
+                            $msg = "Exporting data for instance $instance was succesful."
+                            Log -msg $msg -displayMsg $msg -logLevel "success" -currentDate $currentDate 
+
+                            try {
+                                Logout($header)
+                            }
                             catch {
-                                $message = "Error occurred when extracting data from $($entry.Url)"
-                                Log -msg "An error occurred" -displayMsg $message -logLevel "error" -currentDate $currentDate -instance $instance
-                                Log -msg $message -logLevel "error" -currentDate $currentDate -instance $instance
-                                Log -msg "StatusCode: $($_.Exception.Response.StatusCode.value__)" -logLevel "error" -currentDate $currentDate -instance $instance
-                                Log -msg "Url: $($entry.Url)" -logLevel "error" -currentDate $currentDate -instance $instance
-                                Log -msg "StatusDescription: $($_.Exception.Response.StatusDescription)" -logLevel "error" -currentDate $currentDate -instance $instance
-                                Log -msg "Exception: $($_.Exception)" -logLevel "error" -currentDate $currentDate -instance $instance
-                                Write-Verbose $_.Exception
-                                Write-Verbose $_.Exception.Response
-                                if ($_.Exception.Response.StatusCode -eq 503) {
-                                    $message = "Lost connection to server. Waiting to restablish connection."
-                                    Write-ColorOutput red $message
-                                    Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate
-                                    do {
-                                        $response = ServerHealtCheck("https://$($manifestJson.SubDomain).$($manifestJson.HostName)/en/healthcheck");
-                                    } while ($response.Exception)
-                                    $message = "Server connection reestablished. Resuming export"
-                                    Write-ColorOutput green $message
-                                    Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate
-                                    $i = $i - 1;
-                                }
+                                $message = "Error occurred when logging out"
+                                Log -msg $message -displayMsg $message -logLevel "error" -currentDate $currentDate 
                             }
                         }
                         else {
-                            $message = "Skipping $filePath because file already exists"
-                            Log -msg $message -displayMsg $message -logLevel "info" -currentDate $currentDate -instance $instance
+                            $msg = "Exporting data for instance $instance finished with errors."
+                            $displayMsg = "Exporting data for instance $instance was not successful. Check the log file for more details."
+                            Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate 
                         }
                     }
-                    $msg = "Exporting data for instance $instance was succesful."
-                    Log -msg $msg -displayMsg $msg -logLevel "success" -currentDate $currentDate -instance $instance
-
-                    try {
-                        Logout($header)
-                    }
-                    catch {
-                        $message = "Error occurred when logging out"
-                        Log -msg $message -displayMsg $message -logLevel "error" -currentDate $currentDate -instance $instance
+                    else {
+                        $displayMsg = "An error occurred when looking for manifest file"
+                        Log -msg "Error in finding manifest file" -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate
                     }
                 }
-                else {
-                    $msg = "Exporting data for instance $instance finished with errors."
-                    $displayMsg = "Exporting data for instance $instance was not successful. Check the log file for more details."
-                    Log -msg $msg -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate -instance $instance
-                }
-				
-            }
+            }			
             else {
-                $displayMsg = "An error occurred when looking for manifest folder"
-                Log -msg "Error in finding manifest folder" -displayMsg $displayMsg -logLevel "error" -currentDate $currentDate
+                $msg = "Manifest file path doesn't contain valid json file(s)."
+                Log -msg $msg -displayMsg $msg -logLevel "error" -currentDate $currentDate
             }
-			
+		
+            $msg = "Exporting Instance script run finished."
+            Log -msg $msg -displayMsg $msg -logLevel "success" -currentDate $currentDate
         }
-        $msg = "Exporting Instance script run finished."
-        Log -msg $msg -displayMsg $msg -logLevel "success" -currentDate $currentDate -instance $instance
     }
-        
+    else {
+        $msg = "Manifest file path provided doesn't exist."
+        Log -msg $msg -displayMsg $msg -logLevel "error" -currentDate $currentDate
+    }
 }
 Export

--- a/InstanceExport/PowerShell/InstanceExport.ps1
+++ b/InstanceExport/PowerShell/InstanceExport.ps1
@@ -181,6 +181,10 @@ Function ServerHealtCheck($Uri) {
 }
 
 Function ExportInstanceData() {
+		
+    $message = "Starting exporting data for instance $instance"
+    Log -msg $message -displayMsg $message -logLevel "success" -currentDate $currentDate 
+    
     try {
         CreateDirectoryIfDoesNotExist -directoryPath $directoryPath -currentDate $currentDate
     }
@@ -208,9 +212,6 @@ Function ExportInstanceData() {
         $header = @{
             "authorization" = "Bearer $accessToken"
         }
-		
-        $message = "Starting exporting data for instance $instance"
-        Log -msg $message -displayMsg $message -logLevel "success" -currentDate $currentDate 
 		
         $currentCategory = "";
         $i = 0;

--- a/InstanceExport/PowerShell/README.md
+++ b/InstanceExport/PowerShell/README.md
@@ -10,11 +10,9 @@ In order to use it, you should:
 
 3. Save the `InstanceExport.ps1` file in a directory in your machine like `C:\Users\MyUser\InstanceExport`.
 
-4. Inside the folder created on step 3. create a `manifest` folder. 
+4. Save the `manifest` file we have provided you inside the same directory of step 3. The manifest file should be always in the `JSON` format in order to script be able to read it.
 
-5. Save your manifest file(s) inside the `manifest` folder. The manifest files come in the JSON format and they are necessary to be that way to be read by the script. In this tutorial consider that your file(s) will be named in the pattern yourInstanceName_manifest.json_.
-
-4. Open a new command line interface (CLI) prompt that supports PowerShell commands (depending on your organizational IT policies, you may need to open an elevated/administrator prompt, e.g. by right clicking on the Powershell icon and choosing "Run as administrator"). If you don't have PowerShell installed you can follow instructions at [Installing Power Shell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.5).
+5. Open a new command line interface (CLI) prompt that supports PowerShell commands (depending on your organizational IT policies, you may need to open an elevated/administrator prompt, e.g. by right clicking on the Powershell icon and choosing "Run as administrator"). If you don't have PowerShell installed you can follow instructions at [Installing Power Shell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.5).
 
 Please note that there will be subtle differences between `Windows PowerShell` and `PowerShell 7` command prompts:
 
@@ -30,11 +28,38 @@ Please note that there will be subtle differences between `Windows PowerShell` a
 
    e.g.: `cd C:\Users\MyUser\InstanceExport`
 
-6. In the cli prompt, type the following command. **Be very careful not to click inside the cli prompt while it's running, or it may go into "select mode" and pause.**
+7. In the cli prompt, type the following command. **Be very careful not to click inside the cli prompt while it's running, or it may go into "select mode" and pause.**
 
    `.\InstanceExport`
 
 The process will prompt you to enter the required fields: `$manifestFilePath`, `$exportFilePath`, `$userName` and `$password`. Because you navigated to the directory/folder in step 5, you do not need to enter the full path, just the file names (see example below).
+
+![image](https://github.com/user-attachments/assets/ae36ca77-66f9-4377-84dd-e9fd78417309)
+
+### Alternative scenario
+We also allow to export multiple instances at once using the same `InstanceExport` script. In order to do that possible you should follow almost the same set of instructions:
+
+1. Download the [InstanceExport.ps1](https://github.com/DevResults/DevResultsTools/releases/download/1.0.3/InstanceExport.ps1) PowerShell script.
+
+2. Reach out to us at help@devresults.com to request an Instance Export Manifest. Or Manifests in case you need to export more than one instance you own.
+
+3. Save the `InstanceExport.ps1` file in a directory in your machine like `C:\Users\MyUser\InstanceExport`.
+
+4. Create a `manifest` folder inside the directory of step 3.
+
+5. Save all `manifest` files we have provided you inside the directory of step 4. All manifest files should be always in the `JSON` format in order to script be able to read it.
+
+6. Open a new command line interface (CLI) prompt that supports PowerShell commands (depending on your organizational IT policies, you may need to open an elevated/administrator prompt, e.g. by right clicking on the Powershell icon and choosing "Run as administrator").
+
+7. Navigate to the directory where you have saved the `InstanceExport.ps1` and that has also the `manifest` folder.
+
+   e.g.: `cd C:\Users\MyUser\InstanceExport`
+
+8. In the cli prompt, type the following command. **Be very careful not to click inside the cli prompt while it's running, or it may go into "select mode" and pause.**
+
+   `.\InstanceExport`
+
+The process will prompt you to enter the required fields: `$manifestFilePath`, `$exportFilePath`, `$userName` and `$password`. Because you navigated to the directory/folder in step 7, you do not need to enter the full path, just the folder names (see example below).
 
 ![image](https://github.com/user-attachments/assets/eca84717-d4b1-40a6-a8ef-415f11bdc546)
 
@@ -55,20 +80,21 @@ Please note that if you use `.\InstanceExport.ps1` without passing any parameter
 ### Output
 We expect that things will go smoothly while you are using the DevResults InstanceExport script and that you get a result similar to the following image:
 
-![image](https://github.com/user-attachments/assets/0af5a12c-4c5e-4fc2-b737-1901d2d5739f)
+For single instance Export:
 
-In the folder you've saved the `InstanceExport` script you will noticed that a new folder `export` (or other name you've provided in the $exportFilePath parameter) and inside that folder you will have a folder with the name of the exported instance. You should expect that your data exported will be there in subfolders and a log file will be generated with the pattern `yourInstance_InstanceExport_MM_dd_yyyy_HH_mm_ss_log.txt`
+![image](https://github.com/user-attachments/assets/3376daf2-9950-48df-ad54-7f3d1c7ea677)
 
-![image](https://github.com/user-attachments/assets/2078418b-77ea-4131-9f4a-3f075cc3b300)
-
-In case you are exporting more than one instance you will have a similar output but with more log information like the following image:
+For multiple instances Export
 
 ![image](https://github.com/user-attachments/assets/9f425cd6-34b2-449a-af71-bdc2de9bae6d)
 
-And similarly you will have as many folders as manifests files you have inside your `manifest` folder. You will notice that the script would be generating one folder for each instance you've own.
+In the folder you've saved the `InstanceExport` script you will noticed that a new folder `export` (or other name you've provided in the $exportFilePath parameter) and inside that folder you will have a folder with the name of the exported instance. You should expect that your data exported will be there in subfolders and a log file will be generated with the pattern `InstanceExport_MM_dd_yyyy_HH_mm_ss_log.txt`
 
-![image](https://github.com/user-attachments/assets/be64f831-f668-45e0-aceb-7bb1d153e0b4)
+![image](https://github.com/user-attachments/assets/72e839f5-19ce-4cf0-8359-65254245754d)
 
+And similarly if you followed the process to export more than one instance you will notice in the same folder a folder for each `instance` exported.
+
+![image](https://github.com/user-attachments/assets/e4546e4b-5240-4023-a1fc-b00ad1f33488)
 
 ### Troubleshooting
 

--- a/InstanceExport/PowerShell/README.md
+++ b/InstanceExport/PowerShell/README.md
@@ -4,13 +4,17 @@ At DevResults we value the concept that your data belongs to _you_, and you have
 
 In order to use it, you should:
 
-1. Download the [InstanceExport.ps1](https://github.com/DevResults/DevResultsTools/releases/download/1.0.2/InstanceExport.ps1) PowerShell script.
+1. Download the [InstanceExport.ps1](https://github.com/DevResults/DevResultsTools/releases/download/1.0.3/InstanceExport.ps1) PowerShell script.
 
-2. Reach out to us at help@devresults.com to request an Instance Export Manifest.
+2. Reach out to us at help@devresults.com to request an Instance Export Manifest. Or Manifests in case you need to export more than one instance you own.
 
-3. Save the manifest file in the same directory/folder you have saved the powershell script. It's important to save the file in JSON format and to remember the name of the file. In this tutorial the name we use is _manifest.json_.
+3. Save the `InstanceExport.ps1` file in a directory in your machine like `C:\Users\MyUser\InstanceExport`.
 
-4. Open a new command line interface (CLI) prompt that supports PowerShell commands (depending on your organizational IT policies, you may need to open an elevated/administrator prompt, e.g. by right clicking on the Powershell icon and choosing "Run as administrator"). If you don't have PowerShell installed you can follow instructions at [Installing Power Shell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.3).
+4. Inside the folder created on step 3. create a `manifest` folder. 
+
+5. Save your manifest file(s) inside the `manifest` folder. The manifest files come in the JSON format and they are necessary to be that way to be read by the script. In this tutorial consider that your file(s) will be named in the pattern yourInstanceName_manifest.json_.
+
+4. Open a new command line interface (CLI) prompt that supports PowerShell commands (depending on your organizational IT policies, you may need to open an elevated/administrator prompt, e.g. by right clicking on the Powershell icon and choosing "Run as administrator"). If you don't have PowerShell installed you can follow instructions at [Installing Power Shell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.5).
 
 Please note that there will be subtle differences between `Windows PowerShell` and `PowerShell 7` command prompts:
 
@@ -22,7 +26,7 @@ Please note that there will be subtle differences between `Windows PowerShell` a
 
 ![image](https://user-images.githubusercontent.com/67288628/225463265-13a63f36-ef92-4813-9108-e4e949dc8e3f.png)
 
-5. Navigate to the directory where you have saved the InstanceExport.ps1 and the JSON manifest file.
+6. Navigate to the directory where you have saved the `InstanceExport.ps1` and that has also the `manifest` folder.
 
    e.g.: `cd C:\Users\MyUser\InstanceExport`
 
@@ -38,8 +42,8 @@ It will run automatically after you enter all required fields. The progress of y
 
 The PowerShell script has five parameters that are explained below:
 
-- manifestFilePath: Path (or just file name, if same directory) of the manifest file you have downloaded using step 2, e.g. `C:\Users\MyUser\InstanceExport\manifest.json`.
-- exportFilePath: Path (or just file name, if same directory) to create a folder for the exported files, e.g. `C:\Users\MyUser\InstanceExport\2021_Export\`; you do not need to create this folder manually, the script will do so for you.
+- manifestFilePath: Path (or just folder name, if in the same directory) of the manifest file(s) you have added inside the `manifest` folder from step 3, e.g. `C:\Users\MyUser\InstanceExport\manifest`.
+- exportFilePath: Path (or just folder name, if in the same directory) to create a folder that will contain all instance(s) you are going to export, e.g. `C:\Users\MyUser\InstanceExport\2025_Export\`; you do not need to create this folder manually, the script will do so for you.
 - userName: Your username (work email) for login at DevResults, e.g. `first.last@org.org`.
 - password: Your password for login at DevResults or API Key's Secret. (If you're using a password manager and copy/pasting your password, be aware that CTRL-V does not work in Powershell; try right clicking in the window to paste instead.)
 - overwrite: Optional parameter to confirm whether or not you want to overwrite files that already exist and replace them. This field defaults to `false`, which means that if a file already exists in the exportFilePath, it will be skipped.

--- a/InstanceExport/PowerShell/README.md
+++ b/InstanceExport/PowerShell/README.md
@@ -20,11 +20,11 @@ Please note that there will be subtle differences between `Windows PowerShell` a
 
 `Windows PowerShell` usually comes installed with Windows. It uses the `PowerShell 5` version as you can see from the image below:
 
-![image](https://user-images.githubusercontent.com/67288628/225462134-9a8e0224-3638-46be-9758-5adaf401d655.png)
+![image](https://github.com/user-attachments/assets/3f61a5d3-8b95-43cb-b85d-d030b598aa1f)
 
 `PowerShell 7` is the most recent version of PowerShell released by Microsoft. We recommend using it as it supports longer file paths, which allows our `InstanceExport` script to export files with long names properly. After you install `PowerShell 7` and open its command line prompt, you should be able to see the version of PowerShell using the `$PSVersionTable.PSVersion` command as shown in the image below:
 
-![image](https://user-images.githubusercontent.com/67288628/225463265-13a63f36-ef92-4813-9108-e4e949dc8e3f.png)
+![image](https://github.com/user-attachments/assets/9e7449fb-fe9d-414c-8b93-eaaf7f4ded0b)
 
 6. Navigate to the directory where you have saved the `InstanceExport.ps1` and that has also the `manifest` folder.
 
@@ -36,7 +36,7 @@ Please note that there will be subtle differences between `Windows PowerShell` a
 
 The process will prompt you to enter the required fields: `$manifestFilePath`, `$exportFilePath`, `$userName` and `$password`. Because you navigated to the directory/folder in step 5, you do not need to enter the full path, just the file names (see example below).
 
-![image](https://user-images.githubusercontent.com/67288628/225464180-819117b1-0f24-4ecb-a6c7-ae2d45db34d6.png)
+![image](https://github.com/user-attachments/assets/eca84717-d4b1-40a6-a8ef-415f11bdc546)
 
 It will run automatically after you enter all required fields. The progress of your data export will be logged by each available category. When all is finished you should see the message "Exporting Instance finished".
 
@@ -50,12 +50,25 @@ The PowerShell script has five parameters that are explained below:
 
 Please note that if you use `.\InstanceExport.ps1` without passing any parameters you will be asked to provide the information and will not be able to use the overwrite parameter. If you are more experienced with PowerShell, you can also use the command by passing parameters as shown in the image below:
 
-![image](https://user-images.githubusercontent.com/67288628/225468832-d4fc83d7-4980-45b4-8a69-094f17e67b0d.png)
+![image](https://github.com/user-attachments/assets/de040cf5-f268-4316-8ef5-2276b1e72648)
 
 ### Output
 We expect that things will go smoothly while you are using the DevResults InstanceExport script and that you get a result similar to the following image:
 
-![image](https://user-images.githubusercontent.com/67288628/225465649-ac48360f-af6c-458b-a294-c0e0409d33e3.png)
+![image](https://github.com/user-attachments/assets/0af5a12c-4c5e-4fc2-b737-1901d2d5739f)
+
+In the folder you've saved the `InstanceExport` script you will noticed that a new folder `export` (or other name you've provided in the $exportFilePath parameter) and inside that folder you will have a folder with the name of the exported instance. You should expect that your data exported will be there in subfolders and a log file will be generated with the pattern `yourInstance_InstanceExport_MM_dd_yyyy_HH_mm_ss_log.txt`
+
+![image](https://github.com/user-attachments/assets/2078418b-77ea-4131-9f4a-3f075cc3b300)
+
+In case you are exporting more than one instance you will have a similar output but with more log information like the following image:
+
+![image](https://github.com/user-attachments/assets/9f425cd6-34b2-449a-af71-bdc2de9bae6d)
+
+And similarly you will have as many folders as manifests files you have inside your `manifest` folder. You will notice that the script would be generating one folder for each instance you've own.
+
+![image](https://github.com/user-attachments/assets/be64f831-f668-45e0-aceb-7bb1d153e0b4)
+
 
 ### Troubleshooting
 


### PR DESCRIPTION
### Solves

This PR updates the `InstanceExport` script and the documentation on `README.md` in order to enable that users can export more than one instance data in a single run of the script with the caveat that a given user should be added as `Owner` on each one of the instances they will have the manifest.

### Description

When we created the `InstanceExport` tool we did a good job on allowing users to export a single instance when running it. We failed though to consider that we have some clients that may have multiple instances and the burden of running one by one would be a considerable effort.

I took a peak in order to update the script and allow that we could export more than one instances a given user has access to. I've tested in my tests with a `Tech admin (us)` users and users in the `Owners` group because I believe they will have the best set of permissions to be able to export everything successfully and with fewer possibility of facing any issues in the process.

When updating the script I've added a new parameter `$instance` for a few of the internal Cmdlets we've defined in `InstanceExport` so we would get the `$manifestFilePath` (a folder where users would save a manifest file or more than one manifest file) in order to export one or more instances in a single run of the script. Things should work pretty similar on how they used to work before the changes and how users that already used the tool will only have one different step (which is create a `manifest` folder) in their workflows which should be easy enough for them (I guess). 

### How To Test

0 - Open `DevResults` project on `main` branch
1 - Make sure you build the site and run it
2 - Log in as Tech admin in a local instance
3 - Go to `Users` page
4 - Select a user in the `Owners` group for that site
5 - Make sure to copy the selected user email in a Notepad (you will need later)
6 - Follow the password reset flow so you create a new password for that user (in case you don't know it already)
7 - Log in as that user in the local instance
8 - Open another tab and go to another local instance 
9 - Log in as you Tech admin user
10- Make sure the Tech admin user can `Edit` on that instance
11 - Go to `Users` page and add the user you've chosen on step 4 and using email saved on step 5
12 - Log in as that user in this other local instance
13 - Log out of both instances as the chosen user
14 - Log in as your Tech admin user on both instances
15 - Go to `Instances` page and download manifests file for each one of the instances
16 - Finally, go to `DevResultsTools` repo and copy the `InstanceExport.ps1` from the `enabling-export-multiple-instances` branch
17 - Save the `InstanceExport` script in a folder in your machine
18 - Create a manifest folder in the same folder you've saved the `InstanceExport` script
19 - Open a `PowerShell` window. Here I recommend that you use PowerShell 7 but it might work if you use `Windows Power Shell` too
20 - Navigate to the directory you've saved the `InstanceExport` script
21 - Trigger the export using `.\InstanceExport`
22 - Follow the prompts providing the `manifest` folder
23 - The `exportFilePath`
24 - The chosen user login and password (with Owner permissions)
25 - Wait and see that data will be exported 
26 - Check that a folder for the `exportFilePath` was created and inside you see two folder one for each instance
27 - Go inside each one of the folders and check the sub-folders and the log file and that they do make sense to you from what you've seen in your PS script logs in the command line.
28 - In the `manifest` folder delete move the all manifests to a different folder
29 - Try to run the script again and make sure you got an error and creates a folder in the provided `exportFilePath` with a log file
30 - Try to run the script again and provide in the `manifestFilePath` the path for one of the manifests you've download and make sure it runs without issues as the usual flow for `single` instance export

### Verifications:

**Submitter**:

- [x] Assigned appropriate pull request labels

**Data Reviewer**:

- [ ] Works as described
- [ ] Tasks created for KB, RN, and client comms

**Engineer Reviewer**:

- [ ] Works as described
- [ ] Missed refactoring opportunities?
- [ ] [Clean Code](https://docs.google.com/document/d/1cv42ef3JyRdcNGx5C_17KOK7iY8aGrmiUU3OtBUmZNk/edit)?
- [ ] [Reflects engineering goals](https://github.com/DevResults/DevResults/wiki/Engineering-Goals)
